### PR TITLE
add base_url argument to widget

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,7 +54,8 @@ Imports:
     rlang,
     glue,
     magrittr,
-    shiny
+    shiny,
+    htmltools
 Suggests:
     knitr,
     rmarkdown,

--- a/R/utils-vegaspec.R
+++ b/R/utils-vegaspec.R
@@ -81,6 +81,13 @@
   x
 }
 
+# Method for vegaspec
+.find_urls <- function(spec){
+  unlisted <- unlist(.as_list(spec), recursive = TRUE, use.names = TRUE)
+  url_ix <- grep("^(.*[[:punct:]])*url$", names(unlisted))
+  urls <- unname(unlisted[url_ix])
+  urls
+}
 
 
 

--- a/R/vegawidget.R
+++ b/R/vegawidget.R
@@ -64,7 +64,7 @@
 #'   vegawidget(
 #'     spec_precip,
 #'     base_url =
-#'       "https://raw.githubusercontent.com/vegawidget/vegawidget/master/inst/example-data/seattle-weather.csv"
+#'       "https://raw.githubusercontent.com/vegawidget/vegawidget/master/inst/example-data/"
 #'   )
 #'
 #'   # Local data file
@@ -114,14 +114,14 @@ vegawidget <- function(spec, embed = NULL, width = NULL, height = NULL,
 
   # use internal methods here because spec has already been validated
 
-  x <-
-    .as_json(
-      list(
-        chart_spec = .as_list(spec),
-        embed_options = embed,
-        base_url = base_url
-      )
-    )
+  x <- list(
+    chart_spec = .as_list(spec),
+    embed_options = embed
+  )
+
+  x$base_url <- base_url # Don't include if not there
+
+  x <- .as_json(x)
 
 
   vegawidget <-

--- a/R/vegawidget.R
+++ b/R/vegawidget.R
@@ -38,6 +38,9 @@
 #' @param elementId `character`, explicit element ID for the vegawidget,
 #'   useful if you have other JavaScript that needs to explicitly
 #'   discover and interact with a specific vegawidget
+#' @param base_url `character` The base url for a spec. This could be the path
+#'   to a local directory with a local file that is referenced in the spec,
+#'   or a base remote url. See examples.
 #' @param ... other arguments passed to [htmlwidgets::createWidget()]
 #'
 #' @return S3 object of class `vegawidget` and `htmlwidget`
@@ -46,10 +49,34 @@
 #' @examples
 #'   vegawidget(spec_mtcars, width = 350, height = 350)
 #'
+#'   # Remote url as base_url
+#'   spec_precip <-
+#'     list(
+#'       `$schema` = vega_schema(),
+#'       data = list(url = "seattle-weather.csv"),
+#'       mark = "tick",
+#'       encoding = list(
+#'         x = list(field = "precipitation", type = "quantitative")
+#'       )
+#'     ) %>%
+#'     as_vegaspec()
+#'
+#'   vegawidget(
+#'     spec_precip,
+#'     base_url =
+#'       "https://raw.githubusercontent.com/vegawidget/vegawidget/master/inst/example-data/seattle-weather.csv"
+#'   )
+#'
+#'   # Local data file
+#'   local_path <- system.file("example-data/", package = "vegawidget")
+#'   vegawidget(
+#'     spec_precip,
+#'     base_url = local_path
+#'   )
 #' @export
 #'
 vegawidget <- function(spec, embed = NULL, width = NULL, height = NULL,
-                       elementId = NULL, ...) {
+                       elementId = NULL, base_url = NULL, ...) {
 
   # if `embed` is NULL, check for option
   embed <- embed %||% getOption("vega.embed")
@@ -64,14 +91,38 @@ vegawidget <- function(spec, embed = NULL, width = NULL, height = NULL,
   # autosize (if needed)
   spec <- vw_autosize(spec, width = width, height = height)
 
+  # if base_url is a local directory need to create a depencency
+  if (!is.null(base_url) && dir.exists(base_url)){
+    urls <- .find_urls(spec)
+    full_urls <- file.path(normalizePath(base_url), urls)
+    if (!file.exists(full_urls)) {
+        stop("Local file suggested by base_url and urls in spec does not exist:",
+             full_urls[which(!file.exists(full_urls))])
+    }
+
+    data_dependency <- htmltools::htmlDependency(
+      name = "data",
+      version = "0.0.0",
+      src = c(file = normalizePath(base_url)),
+      attachment = basename(full_urls),
+      all_files = FALSE
+    )
+    base_url <- "lib/data-0.0.0/"
+  } else {
+    data_dependency = NULL
+  }
+
   # use internal methods here because spec has already been validated
+
   x <-
     .as_json(
       list(
         chart_spec = .as_list(spec),
-        embed_options = embed
+        embed_options = embed,
+        base_url = base_url
       )
     )
+
 
   vegawidget <-
     htmlwidgets::createWidget(
@@ -87,6 +138,10 @@ vegawidget <- function(spec, embed = NULL, width = NULL, height = NULL,
         knitr.figure = FALSE
       ),
       elementId = elementId,
+      # Note -- this blocks the user from being able to specify additional
+      # dependencies themselves through ... but there likely wouldn't be
+      # reason to do so...
+      dependencies = data_dependency,
       ...
     )
 

--- a/data-raw/templates/vegawidget.js
+++ b/data-raw/templates/vegawidget.js
@@ -45,6 +45,11 @@ HTMLWidgets.widget({
       // x, object to instantitate htmlwidget
       renderValue: function(x) {
 
+        // if x has base_url use it
+        if (x.base_url !== null){
+          x.embed_options.loader = vega.loader({baseURL: x.base_url});
+        }
+
         // initialise promise
         view_promise =
           vegaEmbed(el, x.chart_spec, opt = x.embed_options)

--- a/inst/htmlwidgets/vegawidget.js
+++ b/inst/htmlwidgets/vegawidget.js
@@ -45,6 +45,11 @@ HTMLWidgets.widget({
       // x, object to instantitate htmlwidget
       renderValue: function(x) {
 
+        // if x has base_url use it
+        if (x.base_url !== null){
+          x.embed_options.loader = vega.loader({baseURL: x.base_url});
+        }
+
         // initialise promise
         view_promise =
           vegaEmbed(el, x.chart_spec, opt = x.embed_options)

--- a/man/image.Rd
+++ b/man/image.Rd
@@ -43,10 +43,10 @@ increased-resolution of retina displays}
 }
 \value{
 \describe{
-\item{\code{vw_to_bitmap()}}{\code{array}, bitmap array}
 \item{\code{vw_to_svg()}}{\code{character}, SVG string}
-\item{\code{vw_write_png()}}{invisible \code{vegaspec} or \code{vegawidget}, called for side-effects}
+\item{\code{vw_to_bitmap()}}{\code{array}, bitmap array}
 \item{\code{vw_write_svg()}}{invisible \code{vegaspec} or \code{vegawidget}, called for side-effects}
+\item{\code{vw_write_png()}}{invisible \code{vegaspec} or \code{vegawidget}, called for side-effects}
 }
 }
 \description{

--- a/man/vegawidget.Rd
+++ b/man/vegawidget.Rd
@@ -86,7 +86,7 @@ of the \strong{entire} rendered chart, including axes, labels, etc.
   vegawidget(
     spec_precip,
     base_url =
-      "https://raw.githubusercontent.com/vegawidget/vegawidget/master/inst/example-data/seattle-weather.csv"
+      "https://raw.githubusercontent.com/vegawidget/vegawidget/master/inst/example-data/"
   )
 
   # Local data file

--- a/man/vegawidget.Rd
+++ b/man/vegawidget.Rd
@@ -5,7 +5,7 @@
 \title{Create a Vega/Vega-Lite htmlwidget}
 \usage{
 vegawidget(spec, embed = NULL, width = NULL, height = NULL,
-  elementId = NULL, ...)
+  elementId = NULL, base_url = NULL, ...)
 }
 \arguments{
 \item{spec}{object to be coerced to \code{vegaspec}, a Vega/Vega-Lite specification}
@@ -25,6 +25,10 @@ the default is to use the height in the chart specification}
 \item{elementId}{\code{character}, explicit element ID for the vegawidget,
 useful if you have other JavaScript that needs to explicitly
 discover and interact with a specific vegawidget}
+
+\item{base_url}{\code{character} The base url for a spec. This could be the path
+to a local directory with a local file that is referenced in the spec,
+or a base remote url. See examples.}
 
 \item{...}{other arguments passed to \code{\link[htmlwidgets:createWidget]{htmlwidgets::createWidget()}}}
 }
@@ -67,6 +71,30 @@ of the \strong{entire} rendered chart, including axes, labels, etc.
 \examples{
   vegawidget(spec_mtcars, width = 350, height = 350)
 
+  # Remote url as base_url
+  spec_precip <-
+    list(
+      `$schema` = vega_schema(),
+      data = list(url = "seattle-weather.csv"),
+      mark = "tick",
+      encoding = list(
+        x = list(field = "precipitation", type = "quantitative")
+      )
+    ) \%>\%
+    as_vegaspec()
+
+  vegawidget(
+    spec_precip,
+    base_url =
+      "https://raw.githubusercontent.com/vegawidget/vegawidget/master/inst/example-data/seattle-weather.csv"
+  )
+
+  # Local data file
+  local_path <- system.file("example-data/", package = "vegawidget")
+  vegawidget(
+    spec_precip,
+    base_url = local_path
+  )
 }
 \seealso{
 \href{https://github.com/vega/vega-embed#options}{vega-embed options},


### PR DESCRIPTION
This allows you to use a local csv file (without having to first read it into R).  Also allows you to have a spec that has names of files and then you provide most of the url through base_url. There are examples in the vegawidget man page added to demonstrate this functionality.

For local files, they still don't show up in Rstudio IDE, similar to remote files. 