### PR TITLE
Add additional check to base_url, fixes #63

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: vegawidget
-Version: 0.2.0.9009
+Version: 0.2.0.9010
 Title: 'Htmlwidget' Renderer for 'Vega' and 'Vega-Lite'
 Description: 'Vega' and 'Vega-Lite' parse text in 'JSON' notation to render 
   chart-specifications into 'HTML'. This package is used to facilitate the 

--- a/data-raw/templates/vegawidget.js
+++ b/data-raw/templates/vegawidget.js
@@ -45,15 +45,10 @@ HTMLWidgets.widget({
       // x, object to instantitate htmlwidget
       renderValue: function(x) {
 
-        console.log(x.embed_options.loader);
-
         // if x has base_url use it
         if (x.base_url !== null && typeof x.base_url !== 'undefined'){
           x.embed_options.loader = vega.loader({baseURL: x.base_url});
         }
-
-        console.log(x.base_url);
-        console.log(x.embed_options.loader);
 
         // initialise promise
         view_promise =

--- a/data-raw/templates/vegawidget.js
+++ b/data-raw/templates/vegawidget.js
@@ -45,11 +45,6 @@ HTMLWidgets.widget({
       // x, object to instantitate htmlwidget
       renderValue: function(x) {
 
-        // if x has base_url use it
-        if (x.base_url !== null && typeof x.base_url !== 'undefined'){
-          x.embed_options.loader = vega.loader({baseURL: x.base_url});
-        }
-
         // initialise promise
         view_promise =
           vegaEmbed(el, x.chart_spec, opt = x.embed_options)

--- a/data-raw/templates/vegawidget.js
+++ b/data-raw/templates/vegawidget.js
@@ -45,10 +45,15 @@ HTMLWidgets.widget({
       // x, object to instantitate htmlwidget
       renderValue: function(x) {
 
+        console.log(x.embed_options.loader);
+
         // if x has base_url use it
-        if (x.base_url !== null){
+        if (x.base_url !== null && typeof x.base_url !== 'undefined'){
           x.embed_options.loader = vega.loader({baseURL: x.base_url});
         }
+
+        console.log(x.base_url);
+        console.log(x.embed_options.loader);
 
         // initialise promise
         view_promise =

--- a/inst/htmlwidgets/vegawidget.js
+++ b/inst/htmlwidgets/vegawidget.js
@@ -45,15 +45,10 @@ HTMLWidgets.widget({
       // x, object to instantitate htmlwidget
       renderValue: function(x) {
 
-        console.log(x.embed_options.loader);
-
         // if x has base_url use it
         if (x.base_url !== null && typeof x.base_url !== 'undefined'){
           x.embed_options.loader = vega.loader({baseURL: x.base_url});
         }
-
-        console.log(x.base_url);
-        console.log(x.embed_options.loader);
 
         // initialise promise
         view_promise =

--- a/inst/htmlwidgets/vegawidget.js
+++ b/inst/htmlwidgets/vegawidget.js
@@ -45,11 +45,6 @@ HTMLWidgets.widget({
       // x, object to instantitate htmlwidget
       renderValue: function(x) {
 
-        // if x has base_url use it
-        if (x.base_url !== null && typeof x.base_url !== 'undefined'){
-          x.embed_options.loader = vega.loader({baseURL: x.base_url});
-        }
-
         // initialise promise
         view_promise =
           vegaEmbed(el, x.chart_spec, opt = x.embed_options)

--- a/inst/htmlwidgets/vegawidget.js
+++ b/inst/htmlwidgets/vegawidget.js
@@ -45,10 +45,15 @@ HTMLWidgets.widget({
       // x, object to instantitate htmlwidget
       renderValue: function(x) {
 
+        console.log(x.embed_options.loader);
+
         // if x has base_url use it
-        if (x.base_url !== null){
+        if (x.base_url !== null && typeof x.base_url !== 'undefined'){
           x.embed_options.loader = vega.loader({baseURL: x.base_url});
         }
+
+        console.log(x.base_url);
+        console.log(x.embed_options.loader);
 
         // initialise promise
         view_promise =


### PR DESCRIPTION
Here's our original spec:

```r
  spec_precip <-
    list(
      `$schema` = vega_schema(),
      data = list(url = "seattle-weather.csv"),
      mark = "tick",
      encoding = list(
        x = list(field = "precipitation", type = "quantitative")
      )
    ) %>%
    as_vegaspec()
```

```r
  path_local <- system.file("example-data/", package = "vegawidget")
```

This worked before, and works now:

```r
vegawidget(spec_precip, base_url = path_local)
```

This works now:

```r
vegawidget(
    spec_precip,
    embed = vega_embed(loader = list(baseURL = "https://raw.githubusercontent.com/vegawidget/vegawidget/master/inst/example-data/"))
)
```