### PR TITLE
bump version, add tests to check for rlang function-deprecation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: vegawidget
-Version: 0.3.1.9001
+Version: 0.3.1.9002
 Title: 'Htmlwidget' for 'Vega' and 'Vega-Lite'
 Description: 'Vega' and 'Vega-Lite' parse text in 'JSON' notation to render 
   chart-specifications into 'HTML'. This package is used to facilitate the 
@@ -59,7 +59,7 @@ Suggests:
     rmarkdown,
     listviewer,
     httr,
-    testthat,
+    testthat (>= 2.1.0),
     yaml,
     fs,
     usethis (>= 1.5.0),

--- a/tests/testthat/test-rlang-check.R
+++ b/tests/testthat/test-rlang-check.R
@@ -1,0 +1,27 @@
+
+# The purpose of these tests is to look for deprecation warnings
+# from the rlang functions we use.
+
+# If we had perfect test coverage, this would not be needed.
+
+library("rlang")
+
+test_that("rlang functions work and are silent", {
+
+  # Trusting this is OK with the tidyverse team, if/when this
+  # causes a revdep error, we commit to fix quickly.
+
+  expect_silent(
+    expect_identical(NULL %||% 4, 4)
+  )
+
+  expect_silent(enquo())
+  expect_silent(eval_tidy(quote(paste("apple", "kiwi"))))
+
+  expect_silent(has_name(mtcars, "mpg"))
+
+  expect_silent(is_string("foo"))
+  expect_silent(is_null(NULL))
+  expect_silent(is_scalar_logical(TRUE))
+
+})


### PR DESCRIPTION
Fixes #116.

This adds some tests that will alert us if any of the rlang functions we use become deprecated.