### PR TITLE
reasses re-exports, add `vw_set_base_url()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 ## New features
 
+* `use_vegawidget()` now re-exports `vw_set_base_url()`, does not re-export `spec_mtcars`. (#150)
+
 * The image functions (`vw_to_svg()` and friends) respect the `baseURL` option set using `vw_set_base_url()`. (#148)
 
 * `vw_set_base_url()`: set the option for vega-embed's default [`baseURL`]((https://github.com/vega/vega-loader#loader). (#147)

--- a/R/use-vegawidget.R
+++ b/R/use-vegawidget.R
@@ -1,24 +1,24 @@
 #' Add vegawidget functions to your package
 #'
 #' These functions are offered to help you import and re-export vegawidget
-#' functions in your package.
+#' functions in your package. For more detail, please see
+#' [this article](https://vegawidget.github.io/vegawidget/articles/articles/import.html).
 #'
 #'  `use_vegawidget()`:
 #'
 #' Adds vegawidget functions:
 #'  - [as_vegaspec()], [vw_as_json()]
-#'  - [vegawidget()], `knit_print()`
-#'  - [vega_embed()]
+#'  - `format()`, `print()`, `knit_print()`
+#'  - [vegawidget()], [vega_embed()], [vw_set_base_url()]
 #'  - [vw_to_svg()] and other image functions
 #'  - [vegawidgetOutput()], [renderVegawidget()]
-#'  - [spec_mtcars]
 #'
 #' In practical terms:
 #' - adds **vegawidget** to `Imports` in your package's DESCRIPTION file.
 #' - adds **processx**, **rsvg**, **png**, **fs** to `Suggests`
 #'   in your package's DESCRIPTION file.
 #' - creates `R/utils-vegawidget.R`
-#' - at your discretion, delete references to functions you do not want
+#' - you can delete references to functions you do not want
 #'   to re-export.
 #'
 #' If you have your own S3 class for a spec, specify the `s3_class_name`
@@ -26,10 +26,10 @@
 #' - add the code within your class's method for
 #'  to coerce your object to a `vegaspec`.
 #'
-#' To permit knit-printing, you will also have to add a call to add
+#' To permit knit-printing of your custom class, you will have to add some code
 #' to your package's `.onLoad()` function.
 #'
-#' `use_vegawidget_interactive()`:
+#' **`use_vegawidget_interactive()`**:
 #'
 #' If you want to add the JavaScript and Shiny functions,
 #' use this after running `use_vegawidget()`. It adds:

--- a/inst/templates/utils-vegawidget.R
+++ b/inst/templates/utils-vegawidget.R
@@ -60,6 +60,17 @@ NULL
 #'
 NULL
 
+#' Set base URL
+#'
+#' See \code{vegawidget::\link[vegawidget]{vw_set_base_url}} for details.
+#'
+#' @name vw_set_base_url
+#' @rdname vw_set_base_url
+#' @importFrom vegawidget vw_set_base_url
+#' @export
+#'
+NULL
+
 #### image functions ####
 
 #' Create or write image
@@ -98,14 +109,4 @@ NULL
 #'
 NULL
 
-#### specs ####
-
-#' Example vegaspecs
-#'
-#' See \code{vegawidget::\link[vegawidget]{spec_mtcars}} for details.
-#'
-#' @name spec_mtcars
-#' @export
-#'
-spec_mtcars <- vegawidget::spec_mtcars
 

--- a/man/use_vegawidget.Rd
+++ b/man/use_vegawidget.Rd
@@ -18,7 +18,8 @@ invisible \code{NULL}, called for side effects
 }
 \description{
 These functions are offered to help you import and re-export vegawidget
-functions in your package.
+functions in your package. For more detail, please see
+\href{https://vegawidget.github.io/vegawidget/articles/articles/import.html}{this article}.
 }
 \details{
 \code{use_vegawidget()}:
@@ -26,11 +27,10 @@ functions in your package.
 Adds vegawidget functions:
 \itemize{
 \item \code{\link[=as_vegaspec]{as_vegaspec()}}, \code{\link[=vw_as_json]{vw_as_json()}}
-\item \code{\link[=vegawidget]{vegawidget()}}, \code{knit_print()}
-\item \code{\link[=vega_embed]{vega_embed()}}
+\item \code{format()}, \code{print()}, \code{knit_print()}
+\item \code{\link[=vegawidget]{vegawidget()}}, \code{\link[=vega_embed]{vega_embed()}}, \code{\link[=vw_set_base_url]{vw_set_base_url()}}
 \item \code{\link[=vw_to_svg]{vw_to_svg()}} and other image functions
 \item \code{\link[=vegawidgetOutput]{vegawidgetOutput()}}, \code{\link[=renderVegawidget]{renderVegawidget()}}
-\item \link{spec_mtcars}
 }
 
 In practical terms:
@@ -39,7 +39,7 @@ In practical terms:
 \item adds \strong{processx}, \strong{rsvg}, \strong{png}, \strong{fs} to \code{Suggests}
 in your package's DESCRIPTION file.
 \item creates \code{R/utils-vegawidget.R}
-\item at your discretion, delete references to functions you do not want
+\item you can delete references to functions you do not want
 to re-export.
 }
 
@@ -50,10 +50,10 @@ argument. You will have to edit \verb{R/utils-vegawidget-<s3_class_name>.R}:
 to coerce your object to a \code{vegaspec}.
 }
 
-To permit knit-printing, you will also have to add a call to add
+To permit knit-printing of your custom class, you will have to add some code
 to your package's \code{.onLoad()} function.
 
-\code{use_vegawidget_interactive()}:
+\strong{\code{use_vegawidget_interactive()}}:
 
 If you want to add the JavaScript and Shiny functions,
 use this after running \code{use_vegawidget()}. It adds:

--- a/vignettes/articles/import.Rmd
+++ b/vignettes/articles/import.Rmd
@@ -10,8 +10,7 @@ You can use `use_vegawidget()` to import and re-export from vegawidget:
 
 - local versions of: `as_vegaspec()`, `print()`, `format()`, `knit_print()`
 - `vw_as_json()`  
-- `vegawidget()`
-- `vega_embed()`
+- `vegawidget()`, `vega_embed()`, `vw_set_base_url()`
 - image functions: `vw_to_svg()`, `vw_to_bitmap()`, `vw_write_svg()`, `vw_write_png()`
 - sample spec: `spec_mtcars`
 - basic Shiny-rendering functions: `renderVegawidget()`, `vegawidgetOutput()`


### PR DESCRIPTION
fix #150

also removes `spec_mtcars` from re-exported objects