### PR TITLE
Fix condition expectations in prevision of testthat breaking change

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: vegawidget
-Version: 0.3.2.9001
+Version: 0.3.2.9002
 Title: 'Htmlwidget' for 'Vega' and 'Vega-Lite'
 Description: 'Vega' and 'Vega-Lite' parse text in 'JSON' notation to render 
   chart-specifications into 'HTML'. This package is used to facilitate the 

--- a/tests/testthat/test-vegaspec.R
+++ b/tests/testthat/test-vegaspec.R
@@ -47,7 +47,9 @@ test_that("vegaspec without $schema warns and adds element", {
   spec_test <- list()
 
   # warning
-  spec_ref <- expect_warning(as_vegaspec(spec_test))
+  expect_warning(
+    spec_ref <- as_vegaspec(spec_test)
+  )
 
   # check result
   expect_identical(


### PR DESCRIPTION
We are planning a breaking change to the condition expectations in testthat release (see NEWS item in https://github.com/r-lib/testthat/pull/1401). This PR implements a preventive fix that works with and without the breaking change.

There is no hurry to get this fix on CRAN since we are skipping one released version of testthat before going through with the change.
