### PR TITLE
add dots to method signatures for `.autosize()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: vegawidget
-Version: 0.4.2.9002
+Version: 0.4.2.9003
 Title: 'Htmlwidget' for 'Vega' and 'Vega-Lite'
 Description: 'Vega' and 'Vega-Lite' parse text in 'JSON' notation to render 
   chart-specifications into 'HTML'. This package is used to facilitate the 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # vegawidget (development version)
 
+* Update method signatures of internal function for autosizing (#225)
+
 * Update vega_version() internals to comport with R 4.4 (#220)
 
 * Update GitHub Actions, Roxygen (#221)

--- a/R/autosize.R
+++ b/R/autosize.R
@@ -55,29 +55,30 @@ vw_autosize <- function(spec, width = NULL, height = NULL) {
     call. = FALSE)
 }
 
-.autosize.vegaspec_hconcat <- function(spec, width = NULL, height = NULL) {
+.autosize.vegaspec_hconcat <- function(spec, width = NULL, height = NULL, ...) {
   # the message that used to be here, and in the other autosize methods,
   # seemed too chatty
   NextMethod()
 }
 
-.autosize.vegaspec_vconcat <- function(spec, width = NULL, height = NULL) {
+.autosize.vegaspec_vconcat <- function(spec, width = NULL, height = NULL, ...) {
   NextMethod()
 }
 
-.autosize.vegaspec_concat <- function(spec, width = NULL, height = NULL) {
+.autosize.vegaspec_concat <- function(spec, width = NULL, height = NULL, ...) {
   NextMethod()
 }
 
-.autosize.vegaspec_facet <- function(spec, width = NULL, height = NULL) {
+.autosize.vegaspec_facet <- function(spec, width = NULL, height = NULL, ...) {
   NextMethod()
 }
 
-.autosize.vegaspec_repeat <- function(spec, width = NULL, height = NULL) {
+.autosize.vegaspec_repeat <- function(spec, width = NULL, height = NULL, ...) {
   NextMethod()
 }
 
-.autosize.vegaspec_vega_lite <- function(spec, width = NULL, height = NULL) {
+.autosize.vegaspec_vega_lite <- function(spec, width = NULL, height = NULL,
+                                         ...) {
 
   if (is.null(c(width, height))) {
     # nothing to do here
@@ -104,7 +105,7 @@ vw_autosize <- function(spec, width = NULL, height = NULL) {
   spec
 }
 
-.autosize.vegaspec_vega <- function(spec, width = NULL, height = NULL) {
+.autosize.vegaspec_vega <- function(spec, width = NULL, height = NULL, ...) {
 
   if (is.null(c(width, height))) {
     # nothing to do here


### PR DESCRIPTION
fix #225