### PR TITLE
fix: remove undocumented use of glue::glue()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: vegawidget
-Version: 0.4.3.9000
+Version: 0.4.3.9001
 Title: 'Htmlwidget' for 'Vega' and 'Vega-Lite'
 Description: 'Vega' and 'Vega-Lite' parse text in 'JSON' notation to render 
   chart-specifications into 'HTML'. This package is used to facilitate the 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # vegawidget (development version)
 
+## Fixes
+
+* Update `vw_handler_add_effect()` to be compliant with upcoming changes in 
+  {glue} (#227)
+
 # vegawidget 0.4.3
 
 * Update method signatures of internal function for autosizing (#225)

--- a/R/js-handler.R
+++ b/R/js-handler.R
@@ -233,7 +233,7 @@ vw_handler_add_effect <- function(vw_handler, body_effect, ...) {
 
   # mix in the parameters
   handler_text <-
-    do.call(glue_js, c(as.list(body_effect$text), list(.envir = params)))
+    glue::glue_data(.x = params, body_effect$text, .open = "${", .sep = "\n")
 
   # append the new effect
   vw_handler$body_effect <- c(vw_handler$body_effect, handler_text)


### PR DESCRIPTION
fix #227

Uses `glue::glue_data()`, rather than `glue::glue()`, to avoid off-label use of environments